### PR TITLE
Use urljoin to fix relative urls

### DIFF
--- a/crawley/http/urls.py
+++ b/crawley/http/urls.py
@@ -59,14 +59,7 @@ class UrlFinder(object):
             Fix relative urls
         """
 
-        parsed_url = urlparse.urlparse(self.response.url)
-
-        if not url.startswith("/"):
-             url = "/%s" % url
-
-        url = "%s://%s%s" % (parsed_url.scheme, parsed_url.netloc, url)
-
-        return url
+        return urlparse.urljoin(self.response.url, url)
 
     def _normalize_url(self, url):
         """


### PR DESCRIPTION
https://docs.python.org/2/library/urlparse.html#urlparse.urljoin provides a robust way to make a relative url into a absolute one.

This fixes some issues like this one:

When accessing this url:
    http://www1.abracom.org.br/cms/opencms/abracom/pt/associados/

We find relative links like this:
    `resultado_busca.html?letra=a`

The browser (chrome) build the absolute url like this:
http://www1.abracom.org.br/cms/opencms/abracom/pt/associados/resultado_busca.html?letra=a

But crawley build the url like this:
http://www1.abracom.org.br/resultado_busca.html?letra=a

urljoin fixes the issue, keeping the right behavior for `/relativeurl`:

In a hypothetical page http://mydomain.com/my/web/page.html:

'/relativeurl.html' link should become 'http://mydomain.com/relativeurl.html'

and

'relativeurl.html' link should become 'http://mydomain.com/my/web/relativeurl.html'
